### PR TITLE
added a .zenodo.json file to control Zenodo's release metadata

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,48 @@
+{
+    "description": "A deep learning tool for time series classification",
+    "license": "Apache-2.0",
+    "title": "mcfly",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Kuppevelt, Dafne"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Meijer, Christiaan"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van Hees, Vincent"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Bos, Patrick"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Spaaks, Jurriaan H."
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Kuzak, Mateusz",
+            "orchid": "0000-0003-0087-6021"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "Hidding, Johan"
+        },
+        {
+            "affiliation": "Netherlands eScience Center",
+            "name": "van der Ploeg, Atze"
+        }
+    ],
+    "access_right": "open",
+    "keywords": [
+          "machine learning",
+          "deep learning",
+          "time series",
+          "automatic classification"
+    ]
+}


### PR DESCRIPTION
Hey I'm experimenting a bit with controlling the metadata that gets attached to your releases on Zenodo. In this PR, I've added a new file ``.zenodo.json`` which now includes the contributors from https://github.com/NLeSC/mcfly/graphs/contributors as ``creators``. If you also want to include people who make issues and such, there is another field ``contributors`` you can add to the ``.zenodo.json``. Items you include there can have an attribute ``type`` which you can set to ``Other`` or another type from the controlled vocabulary [ContactPerson, DataCollector, DataCurator, DataManager, Editor, Researcher, RightsHolder, Sponsor, Other]. 

Anyway long story short, with this ``.zenodo.json`` file, your release process should be less painful.
-Jurriaan