### PR TITLE
Restore_best_weights()

### DIFF
--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -39,7 +39,7 @@ from keras import metrics
 
 def train_models_on_samples(X_train, y_train, X_val, y_val, models,
                             nr_epochs=5, subset_size=100, verbose=True, outputfile=None,
-                            model_path=None, early_stopping=False,
+                            model_path=None, early_stopping=False, 
                             batch_size=20, metric='accuracy'):
     """
     Given a list of compiled models, this function trains
@@ -102,7 +102,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
                 'Invalid metric. The model was not compiled with {} as metric'.format(metric_name))
         if early_stopping:
             callbacks = [
-                EarlyStopping(monitor='val_loss', patience=0, verbose=verbose, mode='auto')]
+                EarlyStopping(monitor='val_loss', patience=0, verbose=verbose, mode='auto', restore_best_weights=True)]
         else:
             callbacks = []
         history = model.fit(X_train_sub, y_train_sub,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scikit-learn>=0.15.0
 scipy>=0.11
 six>=1.10.0
-Keras>=2.0.0
+Keras>=2.2.3
 tensorflow>=0.12.1
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scikit-learn>=0.15.0
 scipy>=0.11
 six>=1.10.0
-Keras=2.2.3
+Keras==2.2.3
 tensorflow>=0.12.1
 h5py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ numpy
 scikit-learn>=0.15.0
 scipy>=0.11
 six>=1.10.0
-Keras>=2.2.3
+Keras=2.2.3
 tensorflow>=0.12.1
 h5py


### PR DESCRIPTION
-Adding Keras `restore_best_weights()` option in `find_architecture.py` module
-Updating Keras Version (>=2.2.3)