### PR TITLE
Data generators Issue #211

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
     - PYTHON_VERSION=3.5
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
+    - PYTHON_VERSION=3.8
   global:
     - MINCONDA_VERSION="latest"
     - MINCONDA_LINUX="Linux-x86_64"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ os:
 
 env:
   matrix:
-    - PYTHON_VERSION=3.5
     - PYTHON_VERSION=3.6
     - PYTHON_VERSION=3.7
     - PYTHON_VERSION=3.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 ## Unreleased
+- Added support for training with Datasets, generators, and other data types supported by Keras
 
 ## v3.0.0
 - Add ResNet architecture

--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -65,7 +65,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
         nr of epochs to use for training one model
     subset_size :
         The number of samples used from the complete train set. If set to 'None'
-        use the entire dataset. Default is 100, but should be adjusted depending
+        use the entire dataset. Default is 100, but should be adjusted depending 
         on the type ans size of the dataset.
     verbose : bool, optional
         flag for displaying verbose output
@@ -76,7 +76,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
     early_stopping_patience: str, int
         Unless 'None' early Stopping is used for the model training. Set to integer
         to define how many epochs without improvement to wait for before stopping.
-        Default is 'auto' in which case the patience will be set to number of epochs/10
+        Default is 'auto' in which case the patience will be set to number of epochs/10 
         (and not bigger than 5).
     batch_size : int
         nr of samples per batch
@@ -94,7 +94,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
     val_losses : list of floats
         validation losses of the models
     """
-
+    
     if subset_size is None:
         subset_size = -1
     if subset_size != -1:

--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -147,8 +147,8 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
 
     # Create dataset for validation data
     if y_val is not None:
-        data_val = tf.data.Dataset.from_tensor_slices((X_val, y_val))
-        data_val = data_val.batch(batch_size)
+        data_val = tf.data.Dataset.from_tensor_slices(
+            (X_val, y_val)).batch(batch_size)
     else:
         data_val = X_val
 

--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -51,21 +51,43 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
 
     Parameters
     ----------
-    X_train : numpy array of shape (num_samples, num_timesteps, num_channels)
-        The input dataset for training
-    y_train : numpy array of shape (num_samples, num_classes)
-        The output classes for the train data, in binary format
-    X_val : numpy array of shape (num_samples_val, num_timesteps, num_channels)
-        The input dataset for validation
-    y_val : numpy array of shape (num_samples_val, num_classes)
-        The output classes for the validation data, in binary format
+    X_train : Supported types:
+        - numpy array
+        - `tf.data` dataset. Should return a tuple of `(inputs, targets)`
+          or `(inputs, targets, sample_weights)`
+        - generator or `keras.utils.Sequence`. Should return a tuple of
+          `(inputs, targets)` or `(inputs, targets, sample_weights)`
+        The input dataset for training of shape
+        (num_samples, num_timesteps, num_channels)
+        More details can be found in the documentation for the Keras
+        function Model.fit() [1]
+    y_train : numpy array
+        The output classes for the train data, in binary format of shape
+        (num_samples, num_classes)
+        If the training data is a dataset, generator or
+        `keras.utils.Sequence`, y_train should not be specified.
+    X_val : Supported types:
+        - numpy array
+        - `tf.data` dataset. Should return a tuple of `(inputs, targets)`
+          or `(inputs, targets, sample_weights)`
+        - generator or `keras.utils.Sequence`. Should return a tuple of
+          `(inputs, targets)` or `(inputs, targets, sample_weights)`
+        The input dataset for validation of shape
+        (num_samples_val, num_timesteps, num_channels)
+        More details can be found in the documentation for the Keras
+        function Model.fit() [1]
+    y_val : numpy array
+        The output classes for the validation data, in binary format of shape
+        (num_samples_val, num_classes)
+        If the validation data is a dataset, generator or
+        `keras.utils.Sequence`, y_val should not be specified.
     models : list of model, params, modeltypes
         List of keras models to train
     nr_epochs : int, optional
         nr of epochs to use for training one model
     subset_size :
         The number of samples used from the complete train set. If set to 'None'
-        use the entire dataset. Default is 100, but should be adjusted depending 
+        use the entire dataset. Default is 100, but should be adjusted depending
         on the type ans size of the dataset.
     verbose : bool, optional
         flag for displaying verbose output
@@ -76,7 +98,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
     early_stopping_patience: str, int
         Unless 'None' early Stopping is used for the model training. Set to integer
         to define how many epochs without improvement to wait for before stopping.
-        Default is 'auto' in which case the patience will be set to number of epochs/10 
+        Default is 'auto' in which case the patience will be set to number of epochs/10
         (and not bigger than 5).
     batch_size : int
         nr of samples per batch
@@ -93,8 +115,10 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
         validation accuraracies of the models
     val_losses : list of floats
         validation losses of the models
+
+    [1]: https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit
     """
-    
+
     if subset_size is None:
         subset_size = -1
     if subset_size != -1:
@@ -239,18 +263,36 @@ def find_best_architecture(X_train, y_train, X_val, y_val, verbose=True,
 
     Parameters
     ----------
-    X_train : numpy array
+    X_train : Supported types:
+        - numpy array
+        - `tf.data` dataset. Should return a tuple of `(inputs, targets)`
+          or `(inputs, targets, sample_weights)`
+        - generator or `keras.utils.Sequence`. Should return a tuple of
+          `(inputs, targets)` or `(inputs, targets, sample_weights)`
         The input dataset for training of shape
         (num_samples, num_timesteps, num_channels)
+        More details can be found in the documentation for the Keras
+        function Model.fit() [1]
     y_train : numpy array
         The output classes for the train data, in binary format of shape
         (num_samples, num_classes)
-    X_val : numpy array
+        If the training data is a dataset, generator or
+        `keras.utils.Sequence`, y_train should not be specified.
+    X_val : Supported types:
+        - numpy array
+        - `tf.data` dataset. Should return a tuple of `(inputs, targets)`
+          or `(inputs, targets, sample_weights)`
+        - generator or `keras.utils.Sequence`. Should return a tuple of
+          `(inputs, targets)` or `(inputs, targets, sample_weights)`
         The input dataset for validation of shape
         (num_samples_val, num_timesteps, num_channels)
+        More details can be found in the documentation for the Keras
+        function Model.fit() [1]
     y_val : numpy array
         The output classes for the validation data, in binary format of shape
         (num_samples_val, num_classes)
+        If the validation data is a dataset, generator or
+        `keras.utils.Sequence`, y_val should not be specified.
     verbose : bool, optional
         flag for displaying verbose output
     number_of_models : int, optiona
@@ -283,6 +325,9 @@ def find_best_architecture(X_train, y_train, X_val, y_val, verbose=True,
         Type of the best model
     knn_acc : float
         accuaracy for kNN prediction on validation set
+
+
+    [1]: https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit
     """
     models = modelgen.generate_models(X_train.shape, y_train.shape[1],
                                       number_of_models=number_of_models,

--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -35,7 +35,7 @@ import numpy as np
 from sklearn import neighbors, metrics as sklearnmetrics
 from tensorflow.keras import metrics
 from tensorflow.keras.callbacks import EarlyStopping
-from tensorflow.data import Dataset
+import tensorflow as tf
 from collections import defaultdict
 
 
@@ -138,7 +138,8 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
         X_train_sub = X_train[:subset_size, :, :]
         y_train_sub = y_train[:subset_size, :]
 
-        data_train = Dataset.from_tensor_slices((X_train_sub, y_train_sub))
+        data_train = tf.data.Dataset.from_tensor_slices(
+            (X_train_sub, y_train_sub))
         data_train = data_train.batch(batch_size)
     else:
         # TODO Subset (is it possible?)
@@ -146,7 +147,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
 
     # Create dataset for validation data
     if y_val is not None:
-        data_val = Dataset.from_tensor_slices((X_val, y_val))
+        data_val = tf.data.Dataset.from_tensor_slices((X_val, y_val))
         data_val = data_val.batch(batch_size)
     else:
         data_val = X_val

--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -137,8 +137,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
         y_train_sub = y_train[:subset_size, :]
 
         data_train = tf.data.Dataset.from_tensor_slices(
-            (X_train_sub, y_train_sub))
-        data_train = data_train.batch(batch_size)
+            (X_train_sub, y_train_sub)).batch(batch_size)
     else:
         # TODO Subset (is it possible?)
         if subset_size != -1:

--- a/mcfly/find_architecture.py
+++ b/mcfly/find_architecture.py
@@ -91,6 +91,7 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
         The number of samples used from the complete train set. If set to 'None'
         use the entire dataset. Default is 100, but should be adjusted depending
         on the type ans size of the dataset.
+        Subset is not supported for tf.data.Dataset objects or generators
     verbose : bool, optional
         flag for displaying verbose output
     outputfile: str, optional
@@ -130,9 +131,6 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
     if metric is not None:
         warnings.warn("Argument 'metric' is deprecated and will be ignored.")
 
-    X_train_sub = X_train[:subset_size, :, :]
-    y_train_sub = y_train[:subset_size, :]
-
     # Create dataset for training data
     if y_train is not None:
         X_train_sub = X_train[:subset_size, :, :]
@@ -143,6 +141,9 @@ def train_models_on_samples(X_train, y_train, X_val, y_val, models,
         data_train = data_train.batch(batch_size)
     else:
         # TODO Subset (is it possible?)
+        if subset_size != -1:
+            warnings.warn("Argument 'subset_size' is not supported for tf.data.Dataset or generators and will be ignored")
+
         data_train = X_train
 
     # Create dataset for validation data

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -136,8 +136,8 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         data_train = tf.data.Dataset.from_tensor_slices((X_train, y_train))
         data_train = data_train.batch(batch_size)
 
-        data_val = tf.data.Dataset.from_tensor_slices((X_val, y_val))
-        data_val = data_val.batch(batch_size)
+        data_val = tf.data.Dataset.from_tensor_slices(
+            (X_val, y_val)).batch(batch_size)
 
         hyperparams = modelgen.generate_CNN_hyperparameter_set(
             get_default_settings())

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -6,6 +6,8 @@ import tensorflow as tf
 import os
 import unittest
 
+from tensorflow.data import Dataset
+
 from test_tools import safe_remove
 
 
@@ -80,11 +82,13 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         assert len(histories) == 0
 
 
-    def train_models_on_samples_generator(self):
+    def train_models_on_samples_with_dataset(self):
+        """Model should be able to train using a dataset as an input"""
         num_timesteps = 100
         num_channels = 2
         num_samples_train = 5
         num_samples_val = 3
+        batch_size = 20
         X_train = np.random.rand(
             num_samples_train,
             num_timesteps,
@@ -93,12 +97,18 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         X_val = np.random.rand(num_samples_val, num_timesteps, num_channels)
         y_val = to_categorical(np.array([0, 1, 1]))
 
+        data_train = Dataset.from_tensor_slices((X_train, y_train))
+        data_train.batch(batch_size)
+
+        data_val = Dataset.from_tensor_slices((X_val, y_val))
+        data_val.batch(batch_size)
+
         histories, val_metrics, val_losses = \
             find_architecture.train_models_on_samples(
-                train_data, None, val_data, None, [],
+                data_train, None, data_val, None, [],
                 nr_epochs=1, subset_size=10, verbose=False,
                 outputfile=None, early_stopping=False,
-                batch_size=20, metric='accuracy')
+                batch_size=batch_size, metric='accuracy')
         assert len(histories) == 0
 
 

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -78,6 +78,29 @@ class FindArchitectureBasicSuite(unittest.TestCase):
                 batch_size=20, metric='accuracy')
         assert len(histories) == 0
 
+
+    def train_models_on_samples_generator(self):
+        num_timesteps = 100
+        num_channels = 2
+        num_samples_train = 5
+        num_samples_val = 3
+        X_train = np.random.rand(
+            num_samples_train,
+            num_timesteps,
+            num_channels)
+        y_train = to_categorical(np.array([0, 0, 1, 1, 1]))
+        X_val = np.random.rand(num_samples_val, num_timesteps, num_channels)
+        y_val = to_categorical(np.array([0, 1, 1]))
+
+        histories, val_metrics, val_losses = \
+            find_architecture.train_models_on_samples(
+                train_data, None, val_data, None, [],
+                nr_epochs=1, subset_size=10, verbose=False,
+                outputfile=None, early_stopping=False,
+                batch_size=20, metric='accuracy')
+        assert len(histories) == 0
+
+
     @unittest.skip('Needs tensorflow API v2. Also, quite a slow test of 15s.')
     def test_find_best_architecture_with_class_weights(self):
         """Model should not ignore tiny class with huge class weight. Note that this test is non-deterministic,

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -6,7 +6,6 @@ import tensorflow as tf
 import os
 import unittest
 
-from tensorflow.data import Dataset
 
 from test_tools import safe_remove
 
@@ -60,6 +59,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         assert 1 >= knn_acc >= 0
 
     # %TODO add test with metric other than accuracy
+    # TODO: Is this a test? It's not set up as one
     def train_models_on_samples_empty(self):
         num_timesteps = 100
         num_channels = 2
@@ -82,7 +82,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         assert len(histories) == 0
 
 
-    def train_models_on_samples_with_dataset(self):
+    def test_train_models_on_samples_with_dataset(self):
         """Model should be able to train using a dataset as an input"""
         num_timesteps = 100
         num_channels = 2
@@ -97,10 +97,10 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         X_val = np.random.rand(num_samples_val, num_timesteps, num_channels)
         y_val = to_categorical(np.array([0, 1, 1]))
 
-        data_train = Dataset.from_tensor_slices((X_train, y_train))
+        data_train = tf.data.Dataset.from_tensor_slices((X_train, y_train))
         data_train.batch(batch_size)
 
-        data_val = Dataset.from_tensor_slices((X_val, y_val))
+        data_val = tf.data.Dataset.from_tensor_slices((X_val, y_val))
         data_val.batch(batch_size)
 
         histories, val_metrics, val_losses = \
@@ -110,6 +110,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
                 outputfile=None, early_stopping=False,
                 batch_size=batch_size, metric='accuracy')
         assert len(histories) == 0
+
 
 
     @unittest.skip('Needs tensorflow API v2. Also, quite a slow test of 15s.')

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -147,7 +147,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         histories, val_metrics, val_losses = \
             find_architecture.train_models_on_samples(
                 data_train, None, data_val, None, models,
-                nr_epochs=1, subset_size=10, verbose=False,
+                nr_epochs=1, subset_size=None, verbose=False,
                 outputfile=None, early_stopping_patience='auto',
                 batch_size=batch_size)
 
@@ -195,7 +195,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         histories, val_metrics, val_losses = \
             find_architecture.train_models_on_samples(
                 data_train, None, data_val, None, models,
-                nr_epochs=1, subset_size=10, verbose=False,
+                nr_epochs=1, subset_size=None, verbose=False,
                 outputfile=None, early_stopping_patience='auto',
                 batch_size=batch_size)
 

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -1,54 +1,19 @@
 from mcfly import find_architecture, modelgen
+from test_modelgen import get_default as get_default_settings
 import numpy as np
 from pytest import approx, raises
-from tensorflow.keras.utils import to_categorical
+from tensorflow.keras.utils import to_categorical, Sequence
 import tensorflow as tf
 import os
 import unittest
+import math
+
 
 
 from test_tools import safe_remove
 
 
 class FindArchitectureBasicSuite(unittest.TestCase):
-
-    # TODO: Move this to an utils file, or obtain it from other source?
-    def get_default_settings(self):
-        """ "Define mcflu default parameters as dictionary. """
-        settings = {'metrics': ['accuracy'],
-                    'model_types': ['CNN', 'DeepConvLSTM', 'ResNet', 'InceptionTime'],
-                    'cnn_min_layers': 1,
-                    'cnn_max_layers': 10,
-                    'cnn_min_filters': 10,
-                    'cnn_max_filters': 100,
-                    'cnn_min_fc_nodes': 10,
-                    'cnn_max_fc_nodes': 2000,
-                    'deepconvlstm_min_conv_layers': 1,
-                    'deepconvlstm_max_conv_layers': 10,
-                    'deepconvlstm_min_conv_filters': 10,
-                    'deepconvlstm_max_conv_filters': 100,
-                    'deepconvlstm_min_lstm_layers': 1,
-                    'deepconvlstm_max_lstm_layers': 5,
-                    'deepconvlstm_min_lstm_dims': 10,
-                    'deepconvlstm_max_lstm_dims': 100,
-                    'resnet_min_network_depth': 2,
-                    'resnet_max_network_depth': 5,
-                    'resnet_min_filters_number': 32,
-                    'resnet_max_filters_number': 128,
-                    'resnet_min_max_kernel_size': 8,
-                    'resnet_max_max_kernel_size': 32,
-                    'IT_min_network_depth': 3,
-                    'IT_max_network_depth': 6,
-                    'IT_min_filters_number': 32,
-                    'IT_max_filters_number': 96,
-                    'IT_min_max_kernel_size': 10,
-                    'IT_max_max_kernel_size': 100,
-                    'low_lr': 1,
-                    'high_lr': 4,
-                    'low_reg': 1,
-                    'high_reg': 4}
-        return settings
-
 
     def test_kNN_accuracy_1(self):
         """
@@ -139,7 +104,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         batch_size = 20
 
         hyperparams = modelgen.generate_CNN_hyperparameter_set(
-            self.get_default_settings())
+            get_default_settings())
         model = modelgen.generate_CNN_model(X_train.shape, 2, **hyperparams)
         models = [(model, hyperparams, "CNN")]
 
@@ -149,8 +114,6 @@ class FindArchitectureBasicSuite(unittest.TestCase):
                 nr_epochs=1, subset_size=10, verbose=False,
                 outputfile=None, early_stopping_patience='auto',
                 batch_size=batch_size)
-
-        assert True # TODO Assertion
 
 
     def test_train_models_on_samples_with_dataset(self):
@@ -177,7 +140,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         data_val = data_val.batch(batch_size)
 
         hyperparams = modelgen.generate_CNN_hyperparameter_set(
-            self.get_default_settings())
+            get_default_settings())
         model = modelgen.generate_CNN_model(X_train.shape, 2, **hyperparams)
         models = [(model, hyperparams, "CNN")]
 
@@ -188,7 +151,53 @@ class FindArchitectureBasicSuite(unittest.TestCase):
                 outputfile=None, early_stopping_patience='auto',
                 batch_size=batch_size)
 
-        assert True # TODO Assertion
+
+    def test_train_models_on_samples_with_generators(self):
+        """
+        Model should be able to train using a dataset as an input
+        """
+        num_timesteps = 100
+        num_channels = 2
+        num_samples_train = 5
+        num_samples_val = 3
+        X_train = np.random.rand(
+            num_samples_train,
+            num_timesteps,
+            num_channels)
+        y_train = to_categorical(np.array([0, 0, 1, 1, 1]))
+        X_val = np.random.rand(num_samples_val, num_timesteps, num_channels)
+        y_val = to_categorical(np.array([0, 1, 1]))
+        batch_size = 20
+
+        class DataGenerator(Sequence):
+            def __init__(self, x_set, y_set, batch_size):
+                self.x, self.y = x_set, y_set
+                self.batch_size = batch_size
+
+            def __len__(self):
+                return math.ceil(len(self.x) / self.batch_size)
+
+            def __getitem__(self, idx):
+                batch_x = self.x[idx * self.batch_size:(idx + 1) *
+                self.batch_size]
+                batch_y = self.y[idx * self.batch_size:(idx + 1) *
+                self.batch_size]
+                return batch_x, batch_y
+
+        data_train = DataGenerator(X_train, y_train, batch_size)
+        data_val = DataGenerator(X_val, y_val, batch_size)
+
+        hyperparams = modelgen.generate_CNN_hyperparameter_set(
+            get_default_settings())
+        model = modelgen.generate_CNN_model(X_train.shape, 2, **hyperparams)
+        models = [(model, hyperparams, "CNN")]
+
+        histories, val_metrics, val_losses = \
+            find_architecture.train_models_on_samples(
+                data_train, None, data_val, None, models,
+                nr_epochs=1, subset_size=10, verbose=False,
+                outputfile=None, early_stopping_patience='auto',
+                batch_size=batch_size)
 
 
     @unittest.skip('Needs tensorflow API v2. Also, quite a slow test of 15s.')

--- a/tests/test_find_architecture.py
+++ b/tests/test_find_architecture.py
@@ -133,8 +133,8 @@ class FindArchitectureBasicSuite(unittest.TestCase):
         y_val = to_categorical(np.array([0, 1, 1]))
         batch_size = 20
 
-        data_train = tf.data.Dataset.from_tensor_slices((X_train, y_train))
-        data_train = data_train.batch(batch_size)
+        data_train = tf.data.Dataset.from_tensor_slices(
+            (X_train, y_train)).batch(batch_size)
 
         data_val = tf.data.Dataset.from_tensor_slices(
             (X_val, y_val)).batch(batch_size)
@@ -154,7 +154,7 @@ class FindArchitectureBasicSuite(unittest.TestCase):
 
     def test_train_models_on_samples_with_generators(self):
         """
-        Model should be able to train using a dataset as an input
+        Model should be able to train using a generator as an input
         """
         num_timesteps = 100
         num_channels = 2

--- a/tests/test_modelgen.py
+++ b/tests/test_modelgen.py
@@ -4,44 +4,45 @@ import numpy as np
 import unittest
 
 
+# TODO: Move this to an utils file, or obtain it from other source?
+def get_default():
+    """ "Define mcflu default parameters as dictionary. """
+    settings = {'metrics': ['accuracy'],
+                'model_types': ['CNN', 'DeepConvLSTM', 'ResNet', 'InceptionTime'],
+                'cnn_min_layers': 1,
+                'cnn_max_layers': 10,
+                'cnn_min_filters': 10,
+                'cnn_max_filters': 100,
+                'cnn_min_fc_nodes': 10,
+                'cnn_max_fc_nodes': 2000,
+                'deepconvlstm_min_conv_layers': 1,
+                'deepconvlstm_max_conv_layers': 10,
+                'deepconvlstm_min_conv_filters': 10,
+                'deepconvlstm_max_conv_filters': 100,
+                'deepconvlstm_min_lstm_layers': 1,
+                'deepconvlstm_max_lstm_layers': 5,
+                'deepconvlstm_min_lstm_dims': 10,
+                'deepconvlstm_max_lstm_dims': 100,
+                'resnet_min_network_depth': 2,
+                'resnet_max_network_depth': 5,
+                'resnet_min_filters_number': 32,
+                'resnet_max_filters_number': 128,
+                'resnet_min_max_kernel_size': 8,
+                'resnet_max_max_kernel_size': 32,
+                'IT_min_network_depth': 3,
+                'IT_max_network_depth': 6,
+                'IT_min_filters_number': 32,
+                'IT_max_filters_number': 96,
+                'IT_min_max_kernel_size': 10,
+                'IT_max_max_kernel_size': 100,
+                'low_lr': 1,
+                'high_lr': 4,
+                'low_reg': 1,
+                'high_reg': 4}
+    return settings
+
 class ModelGenerationSuite(unittest.TestCase):
     """Basic test cases."""
-
-    def get_default(self):
-        """ "Define mcflu default parameters as dictionary. """
-        settings = {'metrics': ['accuracy'],
-                    'model_types': ['CNN', 'DeepConvLSTM', 'ResNet', 'InceptionTime'],
-                    'cnn_min_layers': 1,
-                    'cnn_max_layers': 10,
-                    'cnn_min_filters': 10,
-                    'cnn_max_filters': 100,
-                    'cnn_min_fc_nodes': 10,
-                    'cnn_max_fc_nodes': 2000,
-                    'deepconvlstm_min_conv_layers': 1,
-                    'deepconvlstm_max_conv_layers': 10,
-                    'deepconvlstm_min_conv_filters': 10,
-                    'deepconvlstm_max_conv_filters': 100,
-                    'deepconvlstm_min_lstm_layers': 1,
-                    'deepconvlstm_max_lstm_layers': 5,
-                    'deepconvlstm_min_lstm_dims': 10,
-                    'deepconvlstm_max_lstm_dims': 100,
-                    'resnet_min_network_depth': 2,
-                    'resnet_max_network_depth': 5,
-                    'resnet_min_filters_number': 32,
-                    'resnet_max_filters_number': 128,
-                    'resnet_min_max_kernel_size': 8,
-                    'resnet_max_max_kernel_size': 32,
-                    'IT_min_network_depth': 3,
-                    'IT_max_network_depth': 6,
-                    'IT_min_filters_number': 32,
-                    'IT_max_filters_number': 96,
-                    'IT_min_max_kernel_size': 10,
-                    'IT_max_max_kernel_size': 100,
-                    'low_lr': 1,
-                    'high_lr': 4,
-                    'low_reg': 1,
-                    'high_reg': 4}
-        return settings
 
     def _generate_train_data(self, x_shape, nr_classes):
         X_train = np.random.rand(1, *x_shape[1:])
@@ -114,7 +115,7 @@ class ModelGenerationSuite(unittest.TestCase):
 
     def test_CNN_hyperparameters_nrlayers(self):
         """ Number of Conv layers from range [4, 4] should be 4. """
-        custom_settings = self.get_default()
+        custom_settings = get_default()
         kwargs = {'cnn_min_layers': 4,
                   'cnn_max_layers': 4}
         # Replace default parameters with input
@@ -128,7 +129,7 @@ class ModelGenerationSuite(unittest.TestCase):
 
     def test_CNN_hyperparameters_fcnodes(self):
         """ Number of fc nodes from range [123, 123] should be 123. """
-        custom_settings = self.get_default()
+        custom_settings = get_default()
         kwargs = {'cnn_min_fc_nodes': 123,
                   'cnn_max_fc_nodes': 123}
         # Replace default parameters with input
@@ -159,7 +160,7 @@ class ModelGenerationSuite(unittest.TestCase):
 
     def test_DeepConvLSTM_hyperparameters_nrconvlayers(self):
         """ Number of Conv layers from range [4, 4] should be 4. """
-        custom_settings = self.get_default()
+        custom_settings = get_default()
         kwargs = {'deepconvlstm_min_conv_layers': 4,
                   'deepconvlstm_max_conv_layers': 4}
         # Replace default parameters with input
@@ -230,7 +231,7 @@ class ModelGenerationSuite(unittest.TestCase):
         """ Network depth from range [4,4] should be 4.
         Maximum kernal size from range [10, 10] should be 10.
         Minimum filter number from range [16, 16] should be 16.  """
-        custom_settings = self.get_default()
+        custom_settings = get_default()
         kwargs = {'resnet_min_network_depth': 4,
                   'resnet_mmax_network_depth': 4,
                   'resnet_min_max_kernel_size': 10,
@@ -252,7 +253,7 @@ class ModelGenerationSuite(unittest.TestCase):
     def test_InceptionTime_starts_with_batchnorm(self):
         """ InceptionTime models should always start with a batch normalization layer. """
         model = modelgen.generate_InceptionTime_model((None, 20, 3), 2, 16)
-        
+
         assert 'BatchNormalization' in str(type(model.layers[1])), 'Wrong layer type.'
 
     def test_InceptionTime_first_inception_module(self):
@@ -301,7 +302,7 @@ class ModelGenerationSuite(unittest.TestCase):
         """ Network depth from range [5,5] should be 5.
         Maximum kernal size from range [12, 12] should be 12.
         Minimum filter number from range [32, 32] should be 32.  """
-        custom_settings = self.get_default()
+        custom_settings = get_default()
         kwargs = {'IT_min_network_depth': 5,
                   'IT_max_network_depth': 5,
                   'IT_min_max_kernel_size': 10,


### PR DESCRIPTION
Pull request for issue #211 

Changed the ```train_models_on_samples``` function to support both tensor slices (as it was doing before), ```tf.data.Dataset``` and generators (implemented using ```tf.keras.utils.Sequence```).

Datasets and generators may not be possible to subset.