### PR TITLE
Add cron scheduled trigger for CI workflow for every 10 min

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -4,6 +4,8 @@ on:
   push:
   pull_request:
     types: [opened, reopened]
+  schedule:
+    - cron: '*/5 * * * *'
 
 jobs:
 
@@ -44,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
           # already tested in first_check job
           - python-version: 3.8


### PR DESCRIPTION
Fixes #286 

Adds trigger for CI build workflow to run every 5 minutes (just for testing). The schedule will be changed if the test is successful.