### PR TITLE
Add workflow for pushing release to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Build and upload to PyPI
+
+on:
+  workflow_dispatch:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build universal wheel and source distribution
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Python 
+        uses: actions/checkout@v3
+          python-version: 3.10
+      - name: Python info
+        run: |
+          which python3
+          python3 --version
+      - name: Build package
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install -e .
+      - name: Build wheel and source distribution
+        run: python3 -m build
+      - uses: actions/upload-artifact@v3
+        with:
+          path: dist/*
+
+  upload_test_pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_url: https://test.pypi.org/legacy/
+
+  upload_pypi:
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'release' && github.event.action == 'published'
+    steps:
+      - uses: actions/download-artifact@v3
+        with:
+          name: artifact
+          path: dist
+      - uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Set up Python 
         uses: actions/checkout@v3
-          python-version: 3.10
+          python-version: '3.10'
       - name: Python info
         run: |
           which python3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
       - name: Set up Python 
         uses: actions/checkout@v3
-          python-version: '3.10'
+        with: 
+          python-version: 3.10
       - name: Python info
         run: |
           which python3


### PR DESCRIPTION
Fixes #274

Adds a new workflow for building the package and publishing the build to Test PyPI and PyPI.