### PR TITLE
Change cron job schedule of build workflow to monthly

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
     types: [opened, reopened]
   schedule:
-    - cron: '*/5 * * * *'
+    - cron: '0 0 1 * *'
 
 jobs:
 


### PR DESCRIPTION
Changes the build workflow cron job schedule from "Every 5 minutes" to "The first day of every month".