### PR TITLE
Update build workflow

### DIFF
--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -17,10 +17,11 @@ jobs:
     name: first code check / python-3.10 / ubuntu-latest
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/checkout@v3
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: '3.10'
       - name: Python info
         run: |
           which python3
@@ -52,8 +53,9 @@ jobs:
           - python-version: 3.10
             os: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/checkout@v3
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python info

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Python
-        uses: actions/setup-python@v3
+        uses: actions/checkout@v3
         with:
           python-version: 3.10
       - name: Python info
@@ -53,7 +53,7 @@ jobs:
             os: ubuntu-latest
     steps:
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/checkout@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python info

--- a/.github/workflows/CI_build.yml
+++ b/.github/workflows/CI_build.yml
@@ -1,41 +1,41 @@
 name: CI Build
 
 on:
+  workflow_dispatch:
   push:
+    branches:
+    - main
   pull_request:
-    types: [opened, reopened]
+    branches:
+    - main
   schedule:
     - cron: '0 0 1 * *'
 
 jobs:
 
   first_check:
-    name: first code check / python-3.8 / ubuntu-latest
+    name: first code check / python-3.10 / ubuntu-latest
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
-          python-version: 3.8
+          python-version: 3.10
       - name: Python info
         run: |
-          which python
-          python --version
+          which python3
+          python3 --version
       - name: Build package and create dev environment
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
-      - name: Show pip list
-        run: |
-          pip list
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install -e .[dev]
       - name: Check style against standards using prospector
         shell: bash -l {0}
         run: prospector --profile linter_profile -o grouped -o pylint:pylint-report.txt --zero-exit
       - name: Run unit test / Test coverage with Scrutinizer
         run: |
           coverage run --source=mcfly -m pytest
-          pip install scrutinizer-ocular
+          python3 -m pip install scrutinizer-ocular
           ocular
 
   basic_checks:
@@ -49,25 +49,22 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
         exclude:
           # already tested in first_check job
-          - python-version: 3.8
+          - python-version: 3.10
             os: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Python info
         run: |
-          which python
-          python --version
+          which python3
+          python3 --version
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -e .[dev]
-      - name: Show pip list
-        run: |
-          pip list
+          python3 -m pip install --upgrade pip setuptools wheel
+          python3 -m pip install -e .[dev]
       - name: Run unit tests
-        run: |
-          pytest
+        run: pytest -v
+      - name: Verify that we can build the package
+        run: python3 setup.py sdist bdist_wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,11 @@ jobs:
     name: Build universal wheel and source distribution
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Python 
-        uses: actions/checkout@v3
-        with: 
-          python-version: 3.10
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
       - name: Python info
         run: |
           which python3


### PR DESCRIPTION
Changes the build workflow to only run when pushing or making a PR to `main`.

Changes the `setup-python` action to `v3` and the Python version of the `first_check` job to 3.10.

Adds installations of `setuptools` and `wheel`.

Adds a check if the package can be build from the installation.