### PR TITLE
Change CITATION.cff cff-version to 1.2.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -59,7 +59,7 @@ authors:
     family-names: Lyashevska
     given-names: Olga
     orcid: "https://orcid.org/0000-0002-8686-8550"
-cff-version: "1.0.3"
+cff-version: "1.2.0"
 date-released: 2022-12-21
 doi: "10.5281/zenodo.596127"
 keywords:


### PR DESCRIPTION
cf. @maltelueken 
related to https://github.com/citation-file-format/cff-initializer-javascript/issues/824

The schema version 1.2.0 fixed the regex for ORCID, allowing `X` at the end.